### PR TITLE
Update Dockerfile - apt install curl is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update
 RUN apt install -y dirmngr
 RUN apt install -y apt-transport-https
 RUN apt install -y lsb-release
+RUN apt install -y curl
 RUN apt install -y ca-certificates
 RUN apt remove -y cmdtest
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg --output pubkey.gpg


### PR DESCRIPTION
Hi! I've been trying to do this tutorial, and I've noticed that the 'RUN apt install -y curl' is missing from the Dockerfile. So when I added it everything worked fine, so I thought you could upgrade it for the upcoming users. Cheers.